### PR TITLE
build: add licenser plugin

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,4 +1,4 @@
-This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+This file is part of byte-lens.
 
 Copyright (c) 2024 KoblizekXD
 

--- a/HEADER
+++ b/HEADER
@@ -1,0 +1,16 @@
+This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+
+Copyright (c) 2024 KoblizekXD
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,11 +3,14 @@
 import org.beryx.jlink.JlinkZipTask
 import org.gradle.jvm.tasks.Jar
 
+defaultTasks("licenseFormat")
+
 plugins {
     `java-library`
     application
     id("org.javamodularity.moduleplugin") version "1.8.12"
     id("org.openjfx.javafxplugin") version "0.1.0"
+    id("org.cadixdev.licenser") version "0.6.1"
     id("org.beryx.jlink") version "2.25.0"
 }
 
@@ -48,6 +51,14 @@ tasks.withType<Jar> {
 
 allprojects {
     apply(plugin = "java")
+    apply(plugin = "org.cadixdev.licenser")
+
+    license {
+        header(rootProject.file("HEADER"))
+        include("**/*.java")
+        newLine = true
+    }
+
     dependencies {
         implementation("com.github.javaparser:javaparser-core:3.26.1")
         implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1")

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Decompiler.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Decompiler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Decompiler.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Decompiler.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.decompiler.api;
 

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/NoConflictUtils.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/NoConflictUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/NoConflictUtils.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/NoConflictUtils.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.decompiler.api;
 

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Option.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Option.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Option.java
+++ b/decompiler-api/src/main/java/lol/koblizek/bytelens/core/decompiler/api/Option.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.decompiler.api;
 

--- a/decompiler-api/src/main/java/module-info.java
+++ b/decompiler-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/src/main/java/module-info.java
+++ b/decompiler-api/src/main/java/module-info.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 module lol.koblizek.bytelens.core.decompiler.api {
     requires org.slf4j;
     exports lol.koblizek.bytelens.core.decompiler.api;

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/BytecodeContextSource.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/BytecodeContextSource.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/BytecodeContextSource.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/BytecodeContextSource.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 package lol.koblizek.bytelens.core.decompiler.impl.vineflower;
 
 import org.jetbrains.java.decompiler.main.extern.IContextSource;

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/PreviewResultSaver.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/PreviewResultSaver.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 package lol.koblizek.bytelens.core.decompiler.impl.vineflower;
 
 import org.jetbrains.java.decompiler.main.extern.IResultSaver;

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/PreviewResultSaver.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/PreviewResultSaver.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerDecompiler.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerDecompiler.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 package lol.koblizek.bytelens.core.decompiler.impl.vineflower;
 
 import lol.koblizek.bytelens.core.decompiler.api.Decompiler;

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerDecompiler.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerDecompiler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerLogger.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerLogger.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 package lol.koblizek.bytelens.core.decompiler.impl.vineflower;
 
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;

--- a/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerLogger.java
+++ b/decompiler-api/vineflower-impl/src/main/java/lol/koblizek/bytelens/core/decompiler/impl/vineflower/VineflowerLogger.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/vineflower-impl/src/main/java/module-info.java
+++ b/decompiler-api/vineflower-impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/decompiler-api/vineflower-impl/src/main/java/module-info.java
+++ b/decompiler-api/vineflower-impl/src/main/java/module-info.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 module lol.koblizek.bytelens.core.decompiler.impl.vineflower {
     requires lol.koblizek.bytelens.core.decompiler.api;
     requires vineflower;

--- a/src/main/java/lol/koblizek/bytelens/api/DefaultProject.java
+++ b/src/main/java/lol/koblizek/bytelens/api/DefaultProject.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/DefaultProject.java
+++ b/src/main/java/lol/koblizek/bytelens/api/DefaultProject.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ToolWindow.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ToolWindow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ToolWindow.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ToolWindow.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api;
 

--- a/src/main/java/lol/koblizek/bytelens/api/resource/ResourceManager.java
+++ b/src/main/java/lol/koblizek/bytelens/api/resource/ResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/resource/ResourceManager.java
+++ b/src/main/java/lol/koblizek/bytelens/api/resource/ResourceManager.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.resource;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/DefaultContextMenu.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/DefaultContextMenu.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/DefaultContextMenu.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/DefaultContextMenu.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/ExtendedCodeArea.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/ExtendedCodeArea.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/ExtendedCodeArea.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/ExtendedCodeArea.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/IconMenu.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/IconMenu.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/IconMenu.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/IconMenu.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsButton.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsButton.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsButton.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsButton.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsImage.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsImage.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsImage.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/JetBrainsImage.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/Opener.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/Opener.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/Opener.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/Opener.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/PathField.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/PathField.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/PathField.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/PathField.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/PersistentSplitPane.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/PersistentSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/PersistentSplitPane.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/PersistentSplitPane.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SearchArea.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SearchArea.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SearchArea.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SearchArea.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SidePane.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SidePane.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SidePane.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SidePane.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SideToolBar.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SideToolBar.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SideToolBar.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SideToolBar.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SideToolButton.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SideToolButton.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/SideToolButton.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/SideToolButton.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui;
 

--- a/src/main/java/lol/koblizek/bytelens/api/ui/toolwindows/ProjectTreeToolWindow.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/toolwindows/ProjectTreeToolWindow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/ui/toolwindows/ProjectTreeToolWindow.java
+++ b/src/main/java/lol/koblizek/bytelens/api/ui/toolwindows/ProjectTreeToolWindow.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.ui.toolwindows;
 

--- a/src/main/java/lol/koblizek/bytelens/api/util/IconifiedTreeItem.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/IconifiedTreeItem.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/util/IconifiedTreeItem.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/IconifiedTreeItem.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.util;
 

--- a/src/main/java/lol/koblizek/bytelens/api/util/JavaPatterns.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/JavaPatterns.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/util/JavaPatterns.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/JavaPatterns.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.util;
 

--- a/src/main/java/lol/koblizek/bytelens/api/util/Label.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/Label.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/util/Label.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/Label.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.util;
 

--- a/src/main/java/lol/koblizek/bytelens/api/util/ProjectCreator.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/ProjectCreator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/util/ProjectCreator.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/ProjectCreator.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.util;
 

--- a/src/main/java/lol/koblizek/bytelens/api/util/ProjectException.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/ProjectException.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/api/util/ProjectException.java
+++ b/src/main/java/lol/koblizek/bytelens/api/util/ProjectException.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.api.util;
 

--- a/src/main/java/lol/koblizek/bytelens/core/ByteLens.java
+++ b/src/main/java/lol/koblizek/bytelens/core/ByteLens.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/ByteLens.java
+++ b/src/main/java/lol/koblizek/bytelens/core/ByteLens.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core;
 

--- a/src/main/java/lol/koblizek/bytelens/core/ExecutionExceptionHandler.java
+++ b/src/main/java/lol/koblizek/bytelens/core/ExecutionExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/ExecutionExceptionHandler.java
+++ b/src/main/java/lol/koblizek/bytelens/core/ExecutionExceptionHandler.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core;
 

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/Controller.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/Controller.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/Controller.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/Controller.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.controllers;
 

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/HomeViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/HomeViewController.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/HomeViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/HomeViewController.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.controllers;
 

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/MainViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/MainViewController.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/MainViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/MainViewController.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.controllers;
 

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/NewProjectViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/NewProjectViewController.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/NewProjectViewController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/NewProjectViewController.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.controllers;
 

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/SelectDecompilerModalController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/SelectDecompilerModalController.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/controllers/SelectDecompilerModalController.java
+++ b/src/main/java/lol/koblizek/bytelens/core/controllers/SelectDecompilerModalController.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.controllers;
 

--- a/src/main/java/lol/koblizek/bytelens/core/decompiler/DecompilationManager.java
+++ b/src/main/java/lol/koblizek/bytelens/core/decompiler/DecompilationManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/decompiler/DecompilationManager.java
+++ b/src/main/java/lol/koblizek/bytelens/core/decompiler/DecompilationManager.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.decompiler;
 

--- a/src/main/java/lol/koblizek/bytelens/core/project/DefaultProjectType.java
+++ b/src/main/java/lol/koblizek/bytelens/core/project/DefaultProjectType.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.project;
 

--- a/src/main/java/lol/koblizek/bytelens/core/project/DefaultProjectType.java
+++ b/src/main/java/lol/koblizek/bytelens/core/project/DefaultProjectType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathDeserializer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathDeserializer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathDeserializer.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathSerializer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathSerializer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathSerializer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/CustomNioPathSerializer.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/MavenMetadata.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/MavenMetadata.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/MavenMetadata.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/MavenMetadata.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/Preconditions.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/Preconditions.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/Preconditions.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/StandardDirectoryWatcher.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/StandardDirectoryWatcher.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/StandardDirectoryWatcher.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/StandardDirectoryWatcher.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/StringUtils.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/StringUtils.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/StringUtils.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/lol/koblizek/bytelens/core/utils/ThrowingConsumer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/ThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/lol/koblizek/bytelens/core/utils/ThrowingConsumer.java
+++ b/src/main/java/lol/koblizek/bytelens/core/utils/ThrowingConsumer.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.utils;
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 module lol.koblizek.bytelens {
     requires batik.transcoder;

--- a/src/main/resources/lol/koblizek/bytelens/styles/darcula.css
+++ b/src/main/resources/lol/koblizek/bytelens/styles/darcula.css
@@ -159,6 +159,7 @@ AnchorPane {
 }
 
 /* Code Area */
+
 .styled-text-area .text {
     -fx-font-family: "JetBrains Mono Medium";
     -fx-fill: #dfe1e5;
@@ -240,6 +241,7 @@ ParagraphText {
 }
 
 /* Styles exclusive to home view */
+
 .welcome-button {
     -fx-padding: 12;
     -fx-background-color: #2B2D30;

--- a/src/main/resources/lol/koblizek/bytelens/styles/darcula.css
+++ b/src/main/resources/lol/koblizek/bytelens/styles/darcula.css
@@ -159,7 +159,6 @@ AnchorPane {
 }
 
 /* Code Area */
-
 .styled-text-area .text {
     -fx-font-family: "JetBrains Mono Medium";
     -fx-fill: #dfe1e5;
@@ -241,7 +240,6 @@ ParagraphText {
 }
 
 /* Styles exclusive to home view */
-
 .welcome-button {
     -fx-padding: 12;
     -fx-background-color: #2B2D30;

--- a/src/test/java/lol/koblizek/bytelens/core/decompiler/DecompilationManagerTests.java
+++ b/src/test/java/lol/koblizek/bytelens/core/decompiler/DecompilationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ * This file is part of byte-lens.
  *
  * Copyright (c) 2024 KoblizekXD
  *

--- a/src/test/java/lol/koblizek/bytelens/core/decompiler/DecompilationManagerTests.java
+++ b/src/test/java/lol/koblizek/bytelens/core/decompiler/DecompilationManagerTests.java
@@ -1,19 +1,21 @@
 /*
-Copyright (c) 2024 KoblizekXD
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
-*/
+ * This file is part of byte-lens, licensed under the GNU General Public License v3.0.
+ *
+ * Copyright (c) 2024 KoblizekXD
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
 
 package lol.koblizek.bytelens.core.decompiler;
 


### PR DESCRIPTION
Adds licenser plugin for easier manipulation with license header inside files

This is the most important part: https://github.com/KoblizekXD/byte-lens/pull/2/files#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06R3-R64

license violation error:
![image](https://github.com/user-attachments/assets/5c5cfb9d-0df6-4f6d-b10f-ce96b1b4673c)